### PR TITLE
Disable use of seccomp in systemd-nspawn by default

### DIFF
--- a/man/systemd-nspawn.xml
+++ b/man/systemd-nspawn.xml
@@ -840,6 +840,12 @@
                                 needed.</para></listitem>
                         </varlistentry>
 
+			<varlistentry>
+				<term><option>--enable-seccomp</option></term>
+
+				<listitem><para>Enables seccomp protections for the container.</para></listitem>
+			</varlistentry>
+
                         <xi:include href="standard-options.xml" xpointer="help" />
                         <xi:include href="standard-options.xml" xpointer="version" />
                 </variablelist>

--- a/shell-completion/bash/systemd-nspawn
+++ b/shell-completion/bash/systemd-nspawn
@@ -53,7 +53,7 @@ _systemd_nspawn() {
         local i verb comps
 
         local -A OPTS=(
-               [STANDALONE]='-h --help --version --private-network -b --boot --read-only -q --quiet --share-system --keep-unit --network-veth -j'
+               [STANDALONE]='-h --help --version --private-network -b --boot --read-only -q --quiet --share-system --keep-unit --network-veth -j --enable-seccomp'
                       [ARG]='-D --directory -u --user --uuid --capability --drop-capability --link-journal --bind --bind-ro -M --machine
                              -S --slice --setenv -Z --selinux-context -L --selinux-apifs-context --register --network-interface --network-bridge
                              --personality -i --image --tmpfs --volatile

--- a/shell-completion/zsh/_systemd-nspawn
+++ b/shell-completion/zsh/_systemd-nspawn
@@ -41,4 +41,5 @@ _arguments \
     '--personality=[Control the architecture ("personality") reported by uname(2) in the container.]' \
     {--quiet,-q}'[Turns off any status output by the tool itself.]' \
     {--help,-h}'[Print a short help text and exit.]' \
-    '--version[Print a short version string and exit.]'
+    '--version[Print a short version string and exit.]' \
+    '--enable-seccomp=[Enables seccomp protections.]'


### PR DESCRIPTION
To reenable these seccomp protections, launch the container with "--enable-seccomp" or configure them indepedently in a unit file.
